### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -20,7 +20,7 @@ All Firehose records contain a full JSON dump of the incoming event.
 '''
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && mv ./target/wasm32-wasip2/release/amazon_data_firehose_component.wasm ./firehose.wasm"
+command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && rm -f ./firehose.wasm && mv ./target/wasm32-wasip2/release/amazon_data_firehose_component.wasm ./firehose.wasm"
 output_path = "firehose.wasm"
 
 


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink